### PR TITLE
update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Run `node tools/dev_server.js`
+Run `npm i && node tools/dev_website.js`


### PR DESCRIPTION
There is no filed called `dev_server.js` in the `tools` dir. We can either change the name of the file or change the README instructions. 