### PR TITLE
Add styling to homepage and include package repos

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -78,7 +78,7 @@ exports.lambdaHandler = (event, context, callback) => {
   const response = {
     status: "302",
     headers: {
-      "location": [
+      location: [
         {
           key: "Location",
           value: l

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 // TODO Cron job to update the database with current values.
 const DATABASE = require("./database.json");
+const homepageHTML = require("./homepage");
 const { assert } = console;
 
 const notFound = {
@@ -24,7 +25,7 @@ function proxy(pathname) {
   const rest = pathname.slice(i + 1);
   const nameBranch = pathname.slice(3, i);
   let [name, branch] = nameBranch.split("@", 2);
-  const urlPattern = DATABASE[name];
+  const urlPattern = DATABASE[name] ? DATABASE[name].url : null;
 
   if (!branch) {
     branch = "master";
@@ -41,32 +42,10 @@ function proxy(pathname) {
 }
 exports.proxy = proxy;
 
-const docs = `
-  <h1>deno.land packages</h1>
-  <p>
-    This is a URL redirection service for Deno scripts.
-    The basic format is
-    <code>https://deno.land/x/NAME@BRANCH/SCRIPT.ts</code>
-    If you leave out the branch, it will default to master.
-  </p>
-  <p>
-    To add a package send a pull request to
-    <code>https://github.com/denoland/registry/blob/master/src/database.json</code>
-  </p>
-`;
-
 function indexPage() {
-  let body = `<!DOCTYPE html><html>${docs}<ul>`;
-
-  for (let name in DATABASE) {
-    const url = DATABASE[name];
-    body += `<li>https://deno.land/x/${name}/  &rarr;  ${url} </li>\n`;
-  }
-
-  body += "</ul></html>";
   return {
     status: "200",
-    body,
+    body: homepageHTML,
     headers: {
       "Content-Type": [
         {

--- a/src/database.json
+++ b/src/database.json
@@ -1,27 +1,98 @@
 {
-  "net": "https://raw.githubusercontent.com/denoland/deno_std/${b}/net/",
-  "http": "https://raw.githubusercontent.com/denoland/deno_std/${b}/http/",
-  "fs": "https://raw.githubusercontent.com/denoland/deno_std/${b}/fs/",
-  "std": "https://raw.githubusercontent.com/denoland/deno_std/${b}/",
-  "examples": "https://raw.githubusercontent.com/denoland/deno_std/${b}/examples/",
-  "install": "https://raw.githubusercontent.com/denoland/deno_install/${b}/",
-  "parseargs": "https://raw.githubusercontent.com/bartlomieju/parseargs/${b}/",
-  "flags": "https://raw.githubusercontent.com/denoland/deno_std/${b}/flags/",
-  "leftspread": "https://gist.githubusercontent.com/piscisaureus/a4fa24a16eb12663472a62cc2b0b602f/raw/${b}/leftspread.d.ts",
-  "testing": "https://raw.githubusercontent.com/denoland/deno_std/${b}/testing/",
-  "dotenv": "https://raw.githubusercontent.com/pietvanzoen/deno-dotenv/${b}/",
-  "colors": "https://raw.githubusercontent.com/denoland/deno_std/${b}/colors/",
-  "logging": "https://raw.githubusercontent.com/denoland/deno_std/${b}/log/",
-  "log": "https://raw.githubusercontent.com/denoland/deno_std/${b}/log/",
-  "abc": "https://raw.githubusercontent.com/zhmushan/abc/${b}/",
-  "minimatch": "https://raw.githubusercontent.com/chrisdothtml/deno-minimatch/${b}/",
-  "dejs": "https://raw.githubusercontent.com/syumai/dejs/${b}/",
-  "pretty_assert": "https://raw.githubusercontent.com/bokuweb/deno-pretty-assert/${b}/",
-  "watch": "https://raw.githubusercontent.com/jinjor/deno-watch/${b}/",
-  "task_runner": "https://raw.githubusercontent.com/jinjor/deno-task-runner/${b}/",
-  "ws": "https://raw.githubusercontent.com/denoland/deno_std/${b}/ws/",
-  "io": "https://raw.githubusercontent.com/denoland/deno_std/${b}/io/",
-  "media_types": "https://raw.githubusercontent.com/denoland/deno_std/${b}/media_types/",
-  "textproto": "https://raw.githubusercontent.com/denoland/deno_std/${b}/textproto/",
-  "postgres": "https://raw.githubusercontent.com/bartlomieju/deno-postgres/${b}/"
+  "net": {
+    "url": "https://raw.githubusercontent.com/denoland/deno_std/${b}/net/",
+    "repo": "https://github.com/denoland/deno_std/tree/master/net"
+  },
+  "http": {
+    "url": "https://raw.githubusercontent.com/denoland/deno_std/${b}/http/",
+    "repo": "https://github.com/denoland/deno_std/tree/master/http"
+  },
+  "fs": {
+    "url": "https://raw.githubusercontent.com/denoland/deno_std/${b}/fs/",
+    "repo": "https://github.com/denoland/deno_std/tree/master/fs"
+  },
+  "std": {
+    "url": "https://raw.githubusercontent.com/denoland/deno_std/${b}/",
+    "repo": "https://github.com/denoland/deno_std"
+  },
+  "examples": {
+    "url": "https://raw.githubusercontent.com/denoland/deno_std/${b}/examples/",
+    "repo": "https://github.com/denoland/deno_std/tree/master/examples"
+  },
+  "install": {
+    "url": "https://raw.githubusercontent.com/denoland/deno_install/${b}/",
+    "repo": "https://github.com/denoland/deno_install"
+  },
+  "parseargs": {
+    "url": "https://raw.githubusercontent.com/bartlomieju/parseargs/${b}/",
+    "repo": "https://github.com/bartlomieju/parseargs/"
+  },
+  "flags": {
+    "url": "https://raw.githubusercontent.com/denoland/deno_std/${b}/flags/",
+    "repo": "https://github.com/denoland/deno_std/tree/master/flags"
+  },
+  "testing": {
+    "url": "https://raw.githubusercontent.com/denoland/deno_std/${b}/testing/",
+    "repo": "https://github.com/denoland/deno_std/tree/master/testing"
+  },
+  "dotenv": {
+    "url": "https://raw.githubusercontent.com/pietvanzoen/deno-dotenv/${b}/",
+    "repo": "https://github.com/pietvanzoen/deno-dotenv"
+  },
+  "colors": {
+    "url": "https://raw.githubusercontent.com/denoland/deno_std/${b}/colors/",
+    "repo": "https://github.com/denoland/deno_std/tree/master/colors"
+  },
+  "logging": {
+    "url": "https://raw.githubusercontent.com/denoland/deno_std/${b}/log/",
+    "repo": "https://github.com/denoland/deno_std/tree/master/log"
+  },
+  "log": {
+    "url": "https://raw.githubusercontent.com/denoland/deno_std/${b}/log/",
+    "repo": "https://github.com/denoland/deno_std/tree/master/log"
+  },
+  "abc": {
+    "url": "https://raw.githubusercontent.com/zhmushan/abc/${b}/",
+    "repo": "https://github.com/zhmushan/abc"
+  },
+  "minimatch": {
+    "url": "https://raw.githubusercontent.com/chrisdothtml/deno-minimatch/${b}/",
+    "repo": "https://github.com/chrisdothtml/deno-minimatch"
+  },
+  "dejs": {
+    "url": "https://raw.githubusercontent.com/syumai/dejs/${b}/",
+    "repo": "https://github.com/syumai/dejs"
+  },
+  "pretty_assert": {
+    "url": "https://raw.githubusercontent.com/bokuweb/deno-pretty-assert/${b}/",
+    "repo": "https://github.com/bokuweb/deno-pretty-assert"
+  },
+  "watch": {
+    "url": "https://raw.githubusercontent.com/jinjor/deno-watch/${b}/",
+    "repo": "https://github.com/jinjor/deno-watch"
+  },
+  "task_runner": {
+    "url": "https://raw.githubusercontent.com/jinjor/deno-task-runner/${b}/",
+    "repo": "https://github.com/jinjor/deno-task-runner"
+  },
+  "ws": {
+    "url": "https://raw.githubusercontent.com/denoland/deno_std/${b}/ws/",
+    "repo": "https://github.com/denoland/deno_std/tree/master/ws"
+  },
+  "io": {
+    "url": "https://raw.githubusercontent.com/denoland/deno_std/${b}/io/",
+    "repo": "https://github.com/denoland/deno_std/tree/master/io"
+  },
+  "media_types": {
+    "url": "https://raw.githubusercontent.com/denoland/deno_std/${b}/media_types/",
+    "repo": "https://github.com/denoland/deno_std/tree/master/media_types"
+  },
+  "textproto": {
+    "url": "https://raw.githubusercontent.com/denoland/deno_std/${b}/textproto/",
+    "repo": "https://github.com/denoland/deno_std/tree/master/textproto"
+  },
+  "postgres": {
+    "url": "https://raw.githubusercontent.com/bartlomieju/deno-postgres/${b}/",
+    "repo": "https://github.com/bartlomieju/deno-postgres"
+  }
 }

--- a/src/homepage.js
+++ b/src/homepage.js
@@ -1,6 +1,7 @@
 const DATABASE = require("./database.json");
 
-const LOGO_PATH = "https://raw.githubusercontent.com/denoland/deno/master/website/deno_logo.png";
+const LOGO_PATH =
+  "https://raw.githubusercontent.com/denoland/deno/master/website/deno_logo.png";
 
 const homepageHTML = `
 <!DOCTYPE html>
@@ -97,14 +98,13 @@ const homepageHTML = `
 		<h2>Modules</h2>
 
 		<ul class="modules">
-			${
-				Object.entries(DATABASE)
-					.sort(([nameA], [nameB]) => nameA.localeCompare(nameB))
-					.map(([name, { repo }]) =>
-						`<li><code>https://deno.land/x/<b>${name}</b>/</code> — <a href="${repo}">Repo</a></li>`
-					)
-					.join('\n')
-			}
+			${Object.entries(DATABASE)
+        .sort(([nameA], [nameB]) => nameA.localeCompare(nameB))
+        .map(
+          ([name, { repo }]) =>
+            `<li><code>https://deno.land/x/<b>${name}</b>/</code> — <a href="${repo}">Repo</a></li>`
+        )
+        .join("\n")}
 		</ul>
 
 		<br />

--- a/src/homepage.js
+++ b/src/homepage.js
@@ -43,6 +43,13 @@ const homepageHTML = `
 			margin-bottom: 20px;
 		}
 
+		.packages code {
+			-webkit-user-select: all;
+			-moz-user-select: all;
+			-ms-user-select: all;
+			user-select: all;
+		}
+
 		pre {
 			background: #ddd;
 			padding: 15px;

--- a/src/homepage.js
+++ b/src/homepage.js
@@ -9,7 +9,7 @@ const homepageHTML = `
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
-	<title>Deno packages</title>
+	<title>Deno modules</title>
 	<meta content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' name='viewport' />
 	<style>
 		body {
@@ -38,12 +38,12 @@ const homepageHTML = `
 			font-size: 0.9em;
 		}
 
-		.packages li {
+		.modules li {
 			font-size: 0.9em;
 			margin-bottom: 20px;
 		}
 
-		.packages code {
+		.modules code {
 			-webkit-user-select: all;
 			-moz-user-select: all;
 			-ms-user-select: all;
@@ -88,15 +88,15 @@ const homepageHTML = `
 <body>
 	<main>
 		<img src="${LOGO_PATH}" width="150px" />
-		<h1>Deno Packages</h1>
+		<h1>Deno Modules</h1>
 		<p>This is a URL redirection service for Deno scripts.</p>
 		<p>
-			The basic format is <code>https://deno.land/x/PACKAGE_NAME@BRANCH/SCRIPT.ts</code>. If you leave out the branch, it will default to master.
+			The basic format is <code>https://deno.land/x/MODULE_NAME@BRANCH/SCRIPT.ts</code>. If you leave out the branch, it will default to master.
 		</p>
 
-		<h2 id="available-packages">Available Packages</h2>
+		<h2>Modules</h2>
 
-		<ul class="packages">
+		<ul class="modules">
 			${
 				Object.entries(DATABASE)
 					.sort(([nameA], [nameB]) => nameA.localeCompare(nameB))
@@ -110,7 +110,7 @@ const homepageHTML = `
 		<br />
 		<h2 id="contributing">Contributing</h2>
 
-		<p>To add a package send a pull request to <a href="https://github.com/denoland/registry">https://github.com/denoland/registry</a> with changes in <code>src/database.json</code></p>
+		<p>To add a module send a pull request to <a href="https://github.com/denoland/registry">https://github.com/denoland/registry</a> with changes in <code>src/database.json</code></p>
 	</main>
 </body>
 </html>

--- a/src/homepage.js
+++ b/src/homepage.js
@@ -99,6 +99,7 @@ const homepageHTML = `
 		<ul class="packages">
 			${
 				Object.entries(DATABASE)
+					.sort(([nameA], [nameB]) => nameA.localeCompare(nameB))
 					.map(([name, { repo }]) =>
 						`<li><code>https://deno.land/x/<b>${name}</b>/</code> — <a href="${repo}">Repo</a></li>`
 					)

--- a/src/homepage.js
+++ b/src/homepage.js
@@ -1,0 +1,111 @@
+const DATABASE = require("./database.json");
+
+const LOGO_PATH = "https://raw.githubusercontent.com/denoland/deno/master/website/deno_logo.png";
+
+const homepageHTML = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<title>Deno packages</title>
+	<meta content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' name='viewport' />
+	<style>
+		body {
+			color: #111;
+			background: #f0f0f0;
+			margin: 80px 0;
+			font-family: Arial;
+			font-size: 20px;
+		}
+
+		main {
+			max-width: 800px;
+			margin: 0px auto;
+			padding: 0 10px;
+		}
+		svg {
+			margin: 0px auto;
+		}
+
+		a {
+			color: #333;
+		}
+
+		p {
+			line-height: 1.5;
+			font-size: 0.9em;
+		}
+
+		.packages li {
+			font-size: 0.9em;
+			margin-bottom: 20px;
+		}
+
+		pre {
+			background: #ddd;
+			padding: 15px;
+			word-wrap: normal;
+			overflow-x: auto;
+		}
+
+		code {
+			background: #ddd;
+			padding: 4px 8px;
+		}
+
+		a:hover {
+			background: #aee;
+		}
+
+		table {
+			border-collapse: collapse;
+			border-spacing: 0;
+		}
+
+		td, th {
+			text-align: center;
+			vertical-align: middle;
+			border: 1px solid #aaa;
+			padding: 6px;
+		}
+
+		@media only screen and (max-width: 480px) {
+			body {
+				margin: 10px 0;
+			}
+		}
+	</style>
+</head>
+<body>
+	<main>
+		<img src="${LOGO_PATH}" width="150px" />
+		<h1>Deno Packages</h1>
+		<p>This is a URL redirection service for Deno scripts.</p>
+		<p>
+			The basic format is <code>https://deno.land/x/PACKAGE_NAME@BRANCH/SCRIPT.ts</code>. If you leave out the branch, it will default to master.
+		</p>
+
+		<h2 id="available-packages">Available Packages</h2>
+
+		<ul class="packages">
+			${
+				Object.entries(DATABASE)
+					.map(([name, { repo }]) =>
+						`<li><code>https://deno.land/x/<b>${name}</b>/</code> — <a href="${repo}">Repo</a></li>`
+					)
+					.join('\n')
+			}
+		</ul>
+
+		<br />
+		<h2 id="contributing">Contributing</h2>
+
+		<p>To add a package send a pull request to <a href="https://github.com/denoland/registry">https://github.com/denoland/registry</a> with changes in <code>src/database.json</code></p>
+	</main>
+</body>
+</html>
+`;
+
+module.exports = homepageHTML;

--- a/src/open_homepage.js
+++ b/src/open_homepage.js
@@ -1,0 +1,11 @@
+const { createServer } = require("http");
+const homepageHTML = require("./homepage");
+
+const server = createServer((req, res) => {
+	res.writeHead(200, { "Content-Type": "text/html" });
+	res.end(homepageHTML);
+});
+
+server.listen(3000, () => {
+	console.log("Listening on http://localhost:3000");
+});

--- a/src/open_homepage.js
+++ b/src/open_homepage.js
@@ -2,10 +2,10 @@ const { createServer } = require("http");
 const homepageHTML = require("./homepage");
 
 const server = createServer((req, res) => {
-	res.writeHead(200, { "Content-Type": "text/html" });
-	res.end(homepageHTML);
+  res.writeHead(200, { "Content-Type": "text/html" });
+  res.end(homepageHTML);
 });
 
 server.listen(3000, () => {
-	console.log("Listening on http://localhost:3000");
+  console.log("Listening on http://localhost:3000");
 });


### PR DESCRIPTION
@ry I tried to keep the code changes as minimal as possible (not using any external packages/tools), but if you want I can make a followup PR with some template engine or something.

I also tried to run this locally using aws's `sam local start-api` but with no luck, getting an error. So ended up writing `open_homepage.js` to test the website. 😅 I can remove if it's not actually needed. 

The live html is on https://deno-packages.ristic.tech, I followed deno.land's style — let me know if you want any changes done. 💅 

Closes #31 