### PR TITLE
Add Pogo framework to database.json

### DIFF
--- a/src/database.json
+++ b/src/database.json
@@ -75,6 +75,10 @@
     "url": "https://raw.githubusercontent.com/bartlomieju/parseargs/${b}/",
     "repo": "https://github.com/bartlomieju/parseargs/"
   },
+  "pogo": {
+    "url": "https://raw.githubusercontent.com/sholladay/pogo/${b}/",
+    "repo": "https://github.com/sholladay/pogo"
+  },
   "postgres": {
     "url": "https://raw.githubusercontent.com/bartlomieju/deno-postgres/${b}/",
     "repo": "https://github.com/bartlomieju/deno-postgres"


### PR DESCRIPTION
[Pogo](https://github.com/sholladay/pogo) is a server framework written from the ground up for Deno. It is inspired by [hapi](https://github.com/hapijs/hapi).