### PR TITLE
Add deno_init to database.json

### DIFF
--- a/src/database.json
+++ b/src/database.json
@@ -71,6 +71,10 @@
     "url": "https://raw.githubusercontent.com/denoland/deno/${b}",
     "repo": "https://github.com/denoland/deno"
   },
+  "deno_init": {
+    "url": "https://raw.githubusercontent.com/maxuuell/deno_init/${b}/mod.ts",
+    "repo": "https://github.com/maxuuell/deno_init"
+  },
   "denoget": {
     "url": "https://raw.githubusercontent.com/syumai/denoget/${b}/",
     "repo": "https://github.com/syumai/denoget"


### PR DESCRIPTION
Add new script to set up a basic deno repo.  Meant to be installed with `deno_isntaller`.  Will add to the script as things progress.