### PR TITLE
Fix syntax highlighting

### DIFF
--- a/src/render_code.js
+++ b/src/render_code.js
@@ -59,7 +59,7 @@ module.exports = function renderCode(pathname, code, repo) {
       </head>
       <body>
         <a href="${repo}">View repository on GitHub</a>
-        <pre><code class="${path.extname(pathname) ||
+        <pre><code class="${path.extname(pathname).slice(1) ||
           "no-highlight"}">${lineNumberedCode}</code></pre>
         ${scripts}
       </body>


### PR DESCRIPTION
Fixes #113.

The previous code included the `.` in `.ts`, causing Highlight.js to fall back to detecting language based on the content of the code itself. This fixes that issue, so that files with extensions will now be highlighted properly.