### PR TITLE
Add localhost url to readme and server log

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,21 @@
 
 [![Build Status](https://travis-ci.com/denoland/registry.svg?branch=master)](https://travis-ci.com/denoland/registry)
 
-This is the webserver and database for the https://deno.land/x/ service.
+This is the webserver and database for the [https://deno.land/x/](https://deno.land/x/) service.
 
 This service allows people to create pretty URLs which redirect to github (or
 other content). For example:
 
-```
+```sh
 deno -A https://deno.land/x/std@v0.2.7/http/file_server.ts
 ```
 
 To run the dev server (you shouldn’t need to do this to add a package to the registry):
 
-```shellsession
-$ cd src
-$ npm install
-$ npm start
+```sh
+cd src
+npm install
+npm start
 ```
+
+the registry will launch at [http://localhost:4000/x/](http://localhost:4000/x/)

--- a/src/server.js
+++ b/src/server.js
@@ -55,5 +55,6 @@ server.listen(port, err => {
     throw err;
   } else {
     console.log(`Listening on port ${port}`);
+    console.log(`local registry available at http://localhost:${port}/x/`);
   }
 });


### PR DESCRIPTION
Add a comment and console.log, so people know the registry server listens on localhost:4000/x/ and not localhost:4000.

Also improve the readme according to markdownlint, especially the [$ rule](https://github.com/updownpress/markdown-lint/blob/master/rules/014-commands-show-output.md)